### PR TITLE
Upgrade to ojAlgo v51.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>16</source>
+					<target>16</target>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.ojalgo</groupId>
 			<artifactId>ojalgo</artifactId>
-			<version>50.0.1</version>
+			<version>51.3.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/io/openems/controller/emsig/ojalgo/EnergyModel.java
+++ b/src/io/openems/controller/emsig/ojalgo/EnergyModel.java
@@ -38,6 +38,7 @@ import javax.swing.text.AttributeSet.ColorAttribute;
 
 import org.ojalgo.optimisation.ExpressionsBasedModel;
 import org.ojalgo.optimisation.Optimisation;
+import org.ojalgo.optimisation.integer.IntegerStrategy;
 import org.ojalgo.type.CalendarDateUnit;
 import org.ojalgo.type.context.NumberContext;
 
@@ -53,8 +54,9 @@ public class EnergyModel {
 	public EnergyModel() {
 //		model = new ExpressionsBasedModel();
 		var options = new Optimisation.Options();
-		options.mip_defer = 0.5; // default: 0.9
-		options.mip_gap = 1.0E-2; // default: 1.0E-6
+//      options.mip_defer = 0.5; // default: 0.9
+//      options.mip_gap = 1.0E-2; // default: 1.0E-6
+		options.integer(IntegerStrategy.DEFAULT.withGapTolerance(NumberContext.of(4)));
 //		options.feasibility = NumberContext.of(12, 8);  // default: NumberContext.of(12, 8)
 //		options.iterations_abort = Integer.MAX_VALUE
 //		options.solution = NumberContext.ofScale(14).withMode(RoundingMode.HALF_DOWN);


### PR DESCRIPTION
Update ojAlgo to the latest version and modify configuration to find better solution.

If you want to be absolutely sure to find the very best solution every time then the configuration needs to be:

`options.integer(IntegerStrategy.DEFAULT.withGapTolerance(NumberContext.of(5)));`

With your current configuration

`options.mip_gap = 1.0E-2;`

you stop with the first solution found.